### PR TITLE
fixed typo that was causing syntax error and ./makemk.sh compilation failure

### DIFF
--- a/MacOSX/power/include/lib9.h
+++ b/MacOSX/power/include/lib9.h
@@ -533,5 +533,5 @@ extern char *argv0;
 
 extern	void	setfcr(ulong);
 extern	void	setfsr(ulong);
-extern	ulong	getfcr(void):
+extern	ulong	getfcr(void);
 extern	ulong	getfsr(void);


### PR DESCRIPTION
there was a colon instead of semicolon on line 536 of inferno-os/MacOSX/power/include/lib9.h causing a syntax error and failed compilation