### PR TITLE
fix typos and spelling errors

### DIFF
--- a/appl/acme/regx.b
+++ b/appl/acme/regx.b
@@ -319,7 +319,7 @@ START	  : con		16r10000;	# Start, used for marker on stack
 RBRA	  : con		16r10001;	# Right bracket, ) 
 LBRA	  : con		16r10002;	# Left bracket, ( 
 OR		  : con		16r10003;	# Alternation, | 
-CAT		  : con		16r10004;	# Concatentation, implicit operator 
+CAT		  : con		16r10004;	# Concatenation, implicit operator 
 STAR	  : con		16r10005;	# Closure, * 
 PLUS		  : con		16r10006;	# a+ == aa* 
 QUEST	  : con		16r10007;	# a? == a|nothing, i.e. 0 or 1 a's 

--- a/appl/cmd/auxi/pcmcia.b
+++ b/appl/cmd/auxi/pcmcia.b
@@ -274,7 +274,7 @@ volt(name: string)
 			return;
 		case c {
 		16r7d =>
-			break;		# high impedence when sleeping
+			break;		# high impedance when sleeping
 		16r7e or 16r7f =>
 			microv = 0;	# no connection
 		* =>

--- a/appl/cmd/mk/mk.b
+++ b/appl/cmd/mk/mk.b
@@ -709,7 +709,7 @@ work(node: ref Node, p: ref Node, parc: ref Arc): int
 		else
 			return did;
 	}
-	#  consider no prerequsite case 
+	#  consider no prerequisite case 
 	if(node.prereqs == nil){
 		if(node.time == 0){
 			sys->fprint(sys->fildes(2), "mk: don't know how to make '%s'\n", libc0->ab2s(node.name));
@@ -1580,7 +1580,7 @@ waitup(echildok: int, retstatus: array of int): int
 	p: ref Process;
 	runerrs: int;
 
-	#  first check against the proces slist 
+	#  first check against the process slist 
 	if(retstatus != nil)
 		for(p = phead; p != nil; p = p.f)
 			if(p.pid == retstatus[0]){
@@ -3113,7 +3113,7 @@ exportenv(e: array of Envy)
 			hasvalue = 0;
 		else
 			hasvalue = 1;
-		if(sy == nil && !hasvalue)	#  non-existant null symbol 
+		if(sy == nil && !hasvalue)	#  non-existent null symbol 
 			continue;
 		stob(nam, sys->sprint("/env/%s", libc0->ab2s(e[i].name)));
 		if(sy != nil && !hasvalue){	#  Remove from environment 
@@ -3953,7 +3953,7 @@ atimeof(force: int, name: array of byte): int
 	}
 	else{
 		atimes(archive);
-		#  mark the aggegate as having been done 
+		#  mark the aggregate as having been done 
 		symlooks(libc0->strdup(archive), S_AGG, libc0->s2ab("")).ivalue = t;
 	}
 	#  truncate long member name to sizeof of name field in archive header 

--- a/appl/cmd/sh/sh.b
+++ b/appl/cmd/sh/sh.b
@@ -86,7 +86,7 @@ BUILTINPATH: con "/dis/sh";
 
 DEBUG: con 0;
 
-ENVSEP: con 0;				# word seperator in external environment
+ENVSEP: con 0;				# word separator in external environment
 ENVHASHSIZE: con 7;		# XXX profile usage of this...
 OAPPEND: con 16r80000;		# make sure this doesn't clash with O* constants in sys.m
 OMASK: con 7;

--- a/appl/cmd/sh/sh.y
+++ b/appl/cmd/sh/sh.y
@@ -148,7 +148,7 @@ BUILTINPATH: con "/dis/sh";
 
 DEBUG: con 0;
 
-ENVSEP: con 0;				# word seperator in external environment
+ENVSEP: con 0;				# word separator in external environment
 ENVHASHSIZE: con 7;		# XXX profile usage of this...
 OAPPEND: con 16r80000;		# make sure this doesn't clash with O* constants in sys.m
 OMASK: con 7;

--- a/appl/svc/httpd/httpd.suff
+++ b/appl/svc/httpd/httpd.suff
@@ -28,13 +28,13 @@
 .etx		text		x-setext	-		# [Mosaic]
 .exe		application	octet-stream	-		# DOS executable
 .executable	application	octet-stream	-		# DOS executable
-.exz		application	octet-stream	x-gzip		# gziped DOS executable
+.exz		application	octet-stream	x-gzip		# gzipped DOS executable
 .f		text		plain		-		# fortran-77 program
 .flc		video		x-flc		-
 .fli		video		x-fli		-
 .gif		image		gif		-
 .gtar		application	x-gtar		-		# [Mosaic]
-.gz		-		-		x-gzip		# gziped file
+.gz		-		-		x-gzip		# gzipped file
 .h		text		plain		-		# C header file
 .hdf		application	x-hdf		-
 .hqx		application	octet-stream	-		# Mac BinHex

--- a/appl/wm/unibrowse.b
+++ b/appl/wm/unibrowse.b
@@ -732,7 +732,7 @@ categname(s: string): string
 
 
 fields(s: string, sep: int): list of string
-# seperator can't be '^' (see string(2))
+# separator can't be '^' (see string(2))
 {
 	cl := ""; cl[0] = sep;
 	ret: list of string;

--- a/emu/port/chan.c
+++ b/emu/port/chan.c
@@ -1332,7 +1332,7 @@ skipslash(char *name)
  *  a) is in valid memory.
  *  b) is shorter than 2^16 bytes, so it can fit in a 9P string field.
  *  c) contains no frogs.
- * The first byte is known to be addressible by the requester, so the
+ * The first byte is known to be addressable by the requester, so the
  * routine works for kernel and user memory both.
  * The parameter slashok flags whether a slash character is an error
  * or a valid character.

--- a/emu/port/dat.h
+++ b/emu/port/dat.h
@@ -396,7 +396,7 @@ struct Proc
 	Rendez	sleep;		/* place to sleep */
 	int		killed;		/* by swiproc */
 	int	swipend;	/* software interrupt pending for Prog */
-	int	syscall;	/* set true under sysio for interruptable syscalls */
+	int	syscall;	/* set true under sysio for interruptible syscalls */
 	int	intwait;	/* spin wait for note to turn up */
 	int	sigid;		/* handle used for signal/note/exception */
 	Lock	sysio;		/* note handler lock */
@@ -501,7 +501,7 @@ enum
 	Qmsg		= (1<<1),	/* message stream */
 	Qclosed		= (1<<2),	/* queue has been closed/hungup */
 	Qflow		= (1<<3),	/* producer flow controlled */
-	Qcoalesce	= (1<<4),	/* coallesce packets on read */
+	Qcoalesce	= (1<<4),	/* coalesce packets on read */
 	Qkick		= (1<<5),	/* always call the kick routine after qwrite */
 };
 

--- a/emu/port/dev.c
+++ b/emu/port/dev.c
@@ -190,7 +190,7 @@ devwalk(Chan *c, Chan *nc, char **name, int nname, Dirtab *tab, int ntab, Devgen
 	}
 	/*
 	 * We processed at least one name, so will return some data.
-	 * If we didn't process all nname entries succesfully, we drop
+	 * If we didn't process all nname entries successfully, we drop
 	 * the cloned channel and return just the Qids of the walks.
 	 */
 Done:

--- a/include/freetype/ftincrem.h
+++ b/include/freetype/ftincrem.h
@@ -116,7 +116,7 @@ FT_BEGIN_HEADER
   *   FreeType error code.  0 means success.
   *
   * @note:
-  *   If this function returns succesfully the method
+  *   If this function returns successfully the method
   *   @FT_Incremental_FreeGlyphDataFunc will be called later to release
   *   the data bytes.
   *

--- a/libfreetype/ftglyph.c
+++ b/libfreetype/ftglyph.c
@@ -592,7 +592,7 @@
 
     clazz = glyph->clazz;
 
-    /* when called with a bitmap glyph, do nothing and return succesfully */
+    /* when called with a bitmap glyph, do nothing and return successfully */
     if ( clazz == &ft_bitmap_glyph_class )
       goto Exit;
 

--- a/libfreetype/ftsysio.c
+++ b/libfreetype/ftsysio.c
@@ -73,7 +73,7 @@
     stream->pathname = pathname;
     stream->pos      = 0;
     
-    FT_TRACE1(( "iso.stream.init: opened '%s' (%ld bytes) succesfully\n",
+    FT_TRACE1(( "iso.stream.init: opened '%s' (%ld bytes) successfully\n",
                  pathname, FT_STREAM__SIZE(stream) ));
   }                 
 

--- a/man/1/math-misc
+++ b/man/1/math-misc
@@ -119,7 +119,7 @@ and user defined exceptions.
 Fits a polynomial of degree
 .I deg
 to a set of points (x, y) where x is the independent variable, y the dependent one.
-All x and y values should be seperated by white space
+All x and y values should be separated by white space
 and can be real or integer. The values are read from
 .IR file
 or standard input if none is given. The

--- a/man/3/prof
+++ b/man/3/prof
@@ -71,7 +71,7 @@ allows finer control of the profiling of a module. It is not used at present.
 The read-only file
 .B histogram
 contains statistics about the profiled module. The file contains a list of pairs
-of integers seperated by a space. The first number of the pair is a program counter
+of integers separated by a space. The first number of the pair is a program counter
 value representing the address of a dis instruction. Addresses start from 0 and the
 list is in order of increasing address. The
 second number is the frequency with which this address was sampled. Each read

--- a/man/index
+++ b/man/index
@@ -51529,8 +51529,8 @@ separators	/man/2/dial
 separators	/man/2/prefab-compound
 separators	/man/2/prefab-element
 sepchar	/man/2/bufio
-seperated	/man/1/math-misc
-seperated	/man/3/prof
+separated	/man/1/math-misc
+separated	/man/3/prof
 seprint	/man/10/print
 sepstring	/man/2/bufio
 seq	/man/1/sh-expr

--- a/os/boot/mpc/dosboot.c
+++ b/os/boot/mpc/dosboot.c
@@ -173,7 +173,7 @@ fileaddr(Dosfile *fp, long ltarget)
 	 *  anything else requires a walk through the fat
 	 */
 	if(ltarget >= fp->lcurrent && fp->pcurrent){
-		/* start at the currrent point */
+		/* start at the current point */
 		l = fp->lcurrent;
 		p = fp->pcurrent;
 	} else {

--- a/os/boot/mpc/etherscc.c
+++ b/os/boot/mpc/etherscc.c
@@ -69,7 +69,7 @@ struct Etherparam {
 	ulong	c_pres;		/* preset CRC */
 	ulong	c_mask;		/* constant mask for CRC */
 	ulong	crcec;		/* CRC error counter */
-	ulong	alec;		/* alighnment error counter */
+	ulong	alec;		/* alignment error counter */
 	ulong	disfc;		/* discard frame counter */
 	ushort	pads;		/* short frame PAD characters */
 	ushort	ret_lim;	/* retry limit threshold */

--- a/os/boot/pc/cis.c
+++ b/os/boot/pc/cis.c
@@ -227,7 +227,7 @@ microvolt(Cisdat *cis)
 			return 0;
 		switch(c){
 		case 0x7d:
-			break;		/* high impedence when sleeping */
+			break;		/* high impedance when sleeping */
 		case 0x7e:
 		case 0x7f:
 			microvolts = 0;	/* no connection */

--- a/os/boot/pc/devfloppy.c
+++ b/os/boot/pc/devfloppy.c
@@ -634,7 +634,7 @@ floppyrecal(FDrive *dp)
 
 /*
  *  if the controller or a specific drive is in a confused state,
- *  reset it and get back to a kown state
+ *  reset it and get back to a known state
  */
 static void
 floppyrevive(void)

--- a/os/boot/pc/devfloppy.h
+++ b/os/boot/pc/devfloppy.h
@@ -51,7 +51,7 @@ struct FController
 	int	ncmd;		/* # command bytes */
 	uchar	stat[14];	/* command status */
 	int	nstat;		/* # status bytes */
-	int	confused;	/* controler needs to be reset */
+	int	confused;	/* controller needs to be reset */
 //	Rendez	r;		/* wait here for command termination */
 	int	motor;		/* bit mask of spinning disks */
 //	Rendez	kr;		/* for motor watcher */

--- a/os/boot/pc/devpccard.c
+++ b/os/boot/pc/devpccard.c
@@ -1304,7 +1304,7 @@ microvolt(Cisdat *cis)
 			return 0;
 		switch(c){
 		case 0x7d:
-			break;		/* high impedence when sleeping */
+			break;		/* high impedance when sleeping */
 		case 0x7e:
 		case 0x7f:
 			microvolts = 0;	/* no connection */

--- a/os/boot/pc/dosboot.c
+++ b/os/boot/pc/dosboot.c
@@ -241,7 +241,7 @@ fileaddr(Dosfile *fp, long ltarget)
 	 *  anything else requires a walk through the fat
 	 */
 	if(ltarget >= fp->lcurrent && fp->pcurrent){
-		/* start at the currrent point */
+		/* start at the current point */
 		l = fp->lcurrent;
 		p = fp->pcurrent;
 	} else {

--- a/os/boot/pc/ether2114x.c
+++ b/os/boot/pc/ether2114x.c
@@ -814,7 +814,7 @@ typephymode(Ctlr* ctlr, uchar* block, int wait)
 		return -1;
 
 	/*
-	 * Snarf the media capabilities, nway advertisment,
+	 * Snarf the media capabilities, nway advertisement,
 	 * FDX and TTM bitmaps.
 	 */
 	p = &block[5+len*block[3]+len*block[4+len*block[3]]];
@@ -862,7 +862,7 @@ typephymode(Ctlr* ctlr, uchar* block, int wait)
 
 	/*
 	 * Turn off auto-negotiation, set the auto-negotiation
-	 * advertisment register then start the auto-negotiation
+	 * advertisement register then start the auto-negotiation
 	 * process again.
 	 */
 	miiw(ctlr, ctlr->curphyad, Bmcr, 0);
@@ -1302,7 +1302,7 @@ static uchar leafpnic[] = {
 	0x00,				/* GPR sequence length */
 	0x00,				/* reset sequence length */
 	0x00, 0x78,			/* media capabilities */
-	0xE0, 0x01,			/* Nway advertisment */
+	0xE0, 0x01,			/* Nway advertisement */
 	0x00, 0x50,			/* FDX bitmap */
 	0x00, 0x18,			/* TTM bitmap */
 };
@@ -1363,7 +1363,7 @@ srom(Ctlr* ctlr)
 	/*
 	 * Fake up the SROM for the PNIC.
 	 * It looks like a 21140 with a PHY.
-	 * The MAC address is byte-swapped in the orginal SROM data.
+	 * The MAC address is byte-swapped in the original SROM data.
 	 */
 	if(ctlr->id == Pnic){
 		memmove(&ctlr->srom[20], leafpnic, sizeof(leafpnic));

--- a/os/boot/pc/ether8139.c
+++ b/os/boot/pc/ether8139.c
@@ -475,7 +475,7 @@ rtl8139interrupt(Ureg*, void* arg)
 		 * Only Serr|Timer should be left by now.
 		 * Should anything be done to tidy up? TimerInt isn't
 		 * used so that can be cleared. A PCI bus error is indicated
-		 * by Serr, that's pretty serious; is there anyhing to do
+		 * by Serr, that's pretty serious; is there anything to do
 		 * other than try to reinitialise the chip?
 		 */
 		if((isr & (Serr|Timer)) != 0){

--- a/os/boot/pc/ether82557.c
+++ b/os/boot/pc/ether82557.c
@@ -151,7 +151,7 @@ enum {					/* action command */
 	CbC		= 0x00008000,	/* execution Complete */
 
 	CbNOP		= 0x00000000,
-	CbIAS		= 0x00010000,	/* Indvidual Address Setup */
+	CbIAS		= 0x00010000,	/* Individual Address Setup */
 	CbConfigure	= 0x00020000,
 	CbMAS		= 0x00030000,	/* Multicast Address Setup */
 	CbTransmit	= 0x00040000,

--- a/os/boot/pc/ether82563.c
+++ b/os/boot/pc/ether82563.c
@@ -47,7 +47,7 @@ enum {
 	Fcal		= 0x00000028,	/* Flow Control Address Low */
 	Fcah		= 0x0000002C,	/* Flow Control Address High */
 	Fct		= 0x00000030,	/* Flow Control Type */
-	Kumctrlsta	= 0x00000034,	/* Kumeran Controll and Status Register */
+	Kumctrlsta	= 0x00000034,	/* Kumeran Control and Status Register */
 	Vet		= 0x00000038,	/* VLAN EtherType */
 	Fcttv		= 0x00000170,	/* Flow Control Transmit Timer Value */
 	Txcw		= 0x00000178,	/* Transmit Configuration Word */
@@ -293,10 +293,10 @@ enum {					/* Tctl */
 	CtSHIFT		= 4,
 	ColdMASK	= 0x003FF000,	/* Collision Distance */
 	ColdSHIFT	= 12,
-	Swxoff		= 0x00400000,	/* Sofware XOFF Transmission */
+	Swxoff		= 0x00400000,	/* Software XOFF Transmission */
 	Pbe		= 0x00800000,	/* Packet Burst Enable */
 	Rtlc		= 0x01000000,	/* Re-transmit on Late Collision */
-	Nrtu		= 0x02000000,	/* No Re-transmit on Underrrun */
+	Nrtu		= 0x02000000,	/* No Re-transmit on Underrun */
 };
 
 enum {					/* [RT]xdctl */

--- a/os/boot/pc/ether83815.c
+++ b/os/boot/pc/ether83815.c
@@ -174,9 +174,9 @@ enum {
 	  Brom_dis=	1<<2,	/* disable boot rom interface */
 	  Bem=		1<<0,	/* big-endian mode */
 	Rmear=	0x08,	/* eeprom access */
-	  Mdc=		1<<6,	/* MII mangement check */
+	  Mdc=		1<<6,	/* MII management check */
 	  Mddir=		1<<5,	/* MII management direction */
-	  Mdio=		1<<4,	/* MII mangement data */
+	  Mdio=		1<<4,	/* MII management data */
 	  Eesel=		1<<3,	/* EEPROM chip select */
 	  Eeclk=		1<<2,	/* EEPROM clock */
 	  Eedo=		1<<1,	/* EEPROM data out (from chip) */

--- a/os/boot/pc/etherigbe.c
+++ b/os/boot/pc/etherigbe.c
@@ -307,10 +307,10 @@ enum {					/* Tctl */
 	CtSHIFT		= 4,
 	ColdMASK	= 0x003FF000,	/* Collision Distance */
 	ColdSHIFT	= 12,
-	Swxoff		= 0x00400000,	/* Sofware XOFF Transmission */
+	Swxoff		= 0x00400000,	/* Software XOFF Transmission */
 	Pbe		= 0x00800000,	/* Packet Burst Enable */
 	Rtlc		= 0x01000000,	/* Re-transmit on Late Collision */
-	Nrtu		= 0x02000000,	/* No Re-transmit on Underrrun */
+	Nrtu		= 0x02000000,	/* No Re-transmit on Underrun */
 };
 
 enum {					/* [RT]xdctl */

--- a/os/boot/puma/dosboot.c
+++ b/os/boot/puma/dosboot.c
@@ -173,7 +173,7 @@ fileaddr(Dosfile *fp, long ltarget)
 	 *  anything else requires a walk through the fat
 	 */
 	if(ltarget >= fp->lcurrent && fp->pcurrent){
-		/* start at the currrent point */
+		/* start at the current point */
 		l = fp->lcurrent;
 		p = fp->pcurrent;
 	} else {

--- a/os/boot/puma/hard.c
+++ b/os/boot/puma/hard.c
@@ -62,7 +62,7 @@ struct Ident
 	ushort	reserved0;
 	ushort	heads;		/* # of heads (default) */
 	ushort	b2t;		/* unformatted bytes/track */
-	ushort	b2s;		/* unformated bytes/sector */
+	ushort	b2s;		/* unformatted bytes/sector */
 	ushort	s2t;		/* sectors/track (default) */
 	ushort	reserved1[3];
 /* 10 */

--- a/os/boot/rpcg/dosboot.c
+++ b/os/boot/rpcg/dosboot.c
@@ -173,7 +173,7 @@ fileaddr(Dosfile *fp, long ltarget)
 	 *  anything else requires a walk through the fat
 	 */
 	if(ltarget >= fp->lcurrent && fp->pcurrent){
-		/* start at the currrent point */
+		/* start at the current point */
 		l = fp->lcurrent;
 		p = fp->pcurrent;
 	} else {

--- a/os/boot/rpcg/etherscc.c
+++ b/os/boot/rpcg/etherscc.c
@@ -69,7 +69,7 @@ struct Etherparam {
 	ulong	c_pres;		/* preset CRC */
 	ulong	c_mask;		/* constant mask for CRC */
 	ulong	crcec;		/* CRC error counter */
-	ulong	alec;		/* alighnment error counter */
+	ulong	alec;		/* alignment error counter */
 	ulong	disfc;		/* discard frame counter */
 	ushort	pads;		/* short frame PAD characters */
 	ushort	ret_lim;	/* retry limit threshold */

--- a/os/cerf1110/devata.c
+++ b/os/cerf1110/devata.c
@@ -669,7 +669,7 @@ struct Ident
 	ushort	reserved0;
 	ushort	heads;		/* # of heads (default) */
 	ushort	b2t;		/* unformatted bytes/track */
-	ushort	b2s;		/* unformated bytes/sector */
+	ushort	b2s;		/* unformatted bytes/sector */
 	ushort	s2t;		/* sectors/track (default) */
 	ushort	reserved1[3];
 /* 10 */

--- a/os/cerf250/ether91c111.c
+++ b/os/cerf250/ether91c111.c
@@ -844,7 +844,7 @@ ether91c111reset(Ether* ether)
 	ctlr->bank = -1;
 
 	/*
-	 * do architecture dependent intialisation
+	 * do architecture dependent initialisation
 	 */
 	adinit(ether);
 

--- a/os/ip/esp.c
+++ b/os/ip/esp.c
@@ -25,7 +25,7 @@ enum
 	EsphdrSize	= 28,	// includes IP header
 	IphdrSize	= 20,	// options have been striped
 	EsptailSize	= 2,	// does not include pad or auth data
-	UserhdrSize	= 4,	// user visable header size - if enabled
+	UserhdrSize	= 4,	// user visible header size - if enabled
 };
 
 struct Esphdr

--- a/os/ks32/io.h
+++ b/os/ks32/io.h
@@ -155,7 +155,7 @@ struct TimerReg {
  *	PC compatibility support for PCMCIA drivers
  */
 
-extern ulong ins(ulong);		/* return ulong to prevent unecessary compiler shifting */
+extern ulong ins(ulong);		/* return ulong to prevent unnecessary compiler shifting */
 void outs(ulong, int);
 #define inb(addr)	(*((uchar*)(addr)))
 #define inl(addr)	(*((ulong*)(addr)))

--- a/os/manga/ether8139.c
+++ b/os/manga/ether8139.c
@@ -586,7 +586,7 @@ rtl8139interrupt(Ureg*, void* arg)
 		 * Only Serr|Timer should be left by now.
 		 * Should anything be done to tidy up? TimerInt isn't
 		 * used so that can be cleared. A PCI bus error is indicated
-		 * by Serr, that's pretty serious; is there anyhing to do
+		 * by Serr, that's pretty serious; is there anything to do
 		 * other than try to reinitialise the chip?
 		 */
 		if(isr != 0){

--- a/os/manga/flashif.h
+++ b/os/manga/flashif.h
@@ -52,7 +52,7 @@ void	archflashwp(void *archdata, int);
  */
 
 /*
- * do any device spcific initialisation
+ * do any device specific initialisation
  */
 void archnand_init(void *archdata);
 

--- a/os/mpc/devata.c
+++ b/os/mpc/devata.c
@@ -447,7 +447,7 @@ cmddone(void *a)
 
 /*
  * Wait for the controller to be ready to accept a command.
- * This is protected from intereference by ataclock() by
+ * This is protected from interference by ataclock() by
  * setting dp->usetime before it is called.
  */
 static void
@@ -662,7 +662,7 @@ struct Ident
 	ushort	reserved0;
 	ushort	heads;		/* # of heads (default) */
 	ushort	b2t;		/* unformatted bytes/track */
-	ushort	b2s;		/* unformated bytes/sector */
+	ushort	b2s;		/* unformatted bytes/sector */
 	ushort	s2t;		/* sectors/track (default) */
 	ushort	reserved1[3];
 /* 10 */

--- a/os/mpc/etherscc.c
+++ b/os/mpc/etherscc.c
@@ -74,7 +74,7 @@ struct Etherparam {
 	ulong	c_pres;		/* preset CRC */
 	ulong	c_mask;		/* constant mask for CRC */
 	ulong	crcec;		/* CRC error counter */
-	ulong	alec;		/* alighnment error counter */
+	ulong	alec;		/* alignment error counter */
 	ulong	disfc;		/* discard frame counter */
 	ushort	pads;		/* short frame PAD characters */
 	ushort	ret_lim;	/* retry limit threshold */

--- a/os/pc/devpccard.c
+++ b/os/pc/devpccard.c
@@ -1646,7 +1646,7 @@ microvolt(Cisdat *cis)
 			return 0;
 		switch(c){
 		case 0x7d:
-			break;		/* high impedence when sleeping */
+			break;		/* high impedance when sleeping */
 		case 0x7e:
 		case 0x7f:
 			microvolts = 0;	/* no connection */

--- a/os/pc/ether2114x.c
+++ b/os/pc/ether2114x.c
@@ -956,7 +956,7 @@ typephymode(Ctlr* ctlr, uchar* block, int wait)
 		return -1;
 
 	/*
-	 * Snarf the media capabilities, nway advertisment,
+	 * Snarf the media capabilities, nway advertisement,
 	 * FDX and TTM bitmaps.
 	 */
 	p = &block[5+len*block[3]+len*block[4+len*block[3]]];
@@ -1004,7 +1004,7 @@ typephymode(Ctlr* ctlr, uchar* block, int wait)
 
 	/*
 	 * Turn off auto-negotiation, set the auto-negotiation
-	 * advertisment register then start the auto-negotiation
+	 * advertisement register then start the auto-negotiation
 	 * process again.
 	 */
 	miiw(ctlr, ctlr->curphyad, Bmcr, 0);
@@ -1444,7 +1444,7 @@ static uchar leafpnic[] = {
 	0x00,				/* GPR sequence length */
 	0x00,				/* reset sequence length */
 	0x00, 0x78,			/* media capabilities */
-	0xE0, 0x01,			/* Nway advertisment */
+	0xE0, 0x01,			/* Nway advertisement */
 	0x00, 0x50,			/* FDX bitmap */
 	0x00, 0x18,			/* TTM bitmap */
 };
@@ -1506,7 +1506,7 @@ srom(Ctlr* ctlr)
 	/*
 	 * Fake up the SROM for the PNIC and AMDtek.
 	 * They look like a 21140 with a PHY.
-	 * The MAC address is byte-swapped in the orginal
+	 * The MAC address is byte-swapped in the original
 	 * PNIC SROM data.
 	 */
 	if(ctlr->id == Pnic){

--- a/os/pc/ether8139.c
+++ b/os/pc/ether8139.c
@@ -591,7 +591,7 @@ rtl8139interrupt(Ureg*, void* arg)
 		 * Only Serr|Timerbit should be left by now.
 		 * Should anything be done to tidy up? TimerInt isn't
 		 * used so that can be cleared. A PCI bus error is indicated
-		 * by Serr, that's pretty serious; is there anyhing to do
+		 * by Serr, that's pretty serious; is there anything to do
 		 * other than try to reinitialise the chip?
 		 */
 		if((isr & (Serr|Timerbit)) != 0){

--- a/os/pc/ether82543gc.c
+++ b/os/pc/ether82543gc.c
@@ -251,10 +251,10 @@ enum {					/* Tctl */
 	CtSHIFT		= 4,
 	ColdMASK	= 0x003FF000,	/* Collision Distance */
 	ColdSHIFT	= 12,
-	Swxoff		= 0x00400000,	/* Sofware XOFF Transmission */
+	Swxoff		= 0x00400000,	/* Software XOFF Transmission */
 	Pbe		= 0x00800000,	/* Packet Burst Enable */
 	Rtlc		= 0x01000000,	/* Re-transmit on Late Collision */
-	Nrtu		= 0x02000000,	/* No Re-transmit on Underrrun */
+	Nrtu		= 0x02000000,	/* No Re-transmit on Underrun */
 };
 
 enum {					/* [RT]xdctl */

--- a/os/pc/ether83815.c
+++ b/os/pc/ether83815.c
@@ -188,9 +188,9 @@ enum {
 	  Brom_dis=	1<<2,	/* disable boot rom interface */
 	  Bem=		1<<0,	/* big-endian mode */
 	Rmear=	0x08,		/* eeprom access */
-	  Mdc=		1<<6,	/* MII mangement check */
+	  Mdc=		1<<6,	/* MII management check */
 	  Mddir=	1<<5,	/* MII management direction */
-	  Mdio=		1<<4,	/* MII mangement data */
+	  Mdio=		1<<4,	/* MII management data */
 	  Eesel=	1<<3,	/* EEPROM chip select */
 	  Eeclk=	1<<2,	/* EEPROM clock */
 	  Eedo=		1<<1,	/* EEPROM data out (from chip) */

--- a/os/pc/etherigbe.c
+++ b/os/pc/etherigbe.c
@@ -317,10 +317,10 @@ enum {					/* Tctl */
 	CtSHIFT		= 4,
 	ColdMASK	= 0x003FF000,	/* Collision Distance */
 	ColdSHIFT	= 12,
-	Swxoff		= 0x00400000,	/* Sofware XOFF Transmission */
+	Swxoff		= 0x00400000,	/* Software XOFF Transmission */
 	Pbe		= 0x00800000,	/* Packet Burst Enable */
 	Rtlc		= 0x01000000,	/* Re-transmit on Late Collision */
-	Nrtu		= 0x02000000,	/* No Re-transmit on Underrrun */
+	Nrtu		= 0x02000000,	/* No Re-transmit on Underrun */
 };
 
 enum {					/* [RT]xdctl */

--- a/os/pc/floppy.h
+++ b/os/pc/floppy.h
@@ -37,7 +37,7 @@ struct FDrive
  */
 struct FController
 {
-	QLock;			/* exclusive access to the contoller */
+	QLock;			/* exclusive access to the controller */
 
 	int	ndrive;
 	FDrive	*d;		/* the floppy drives */
@@ -47,7 +47,7 @@ struct FController
 	int	ncmd;		/* # command bytes */
 	uchar	stat[14];	/* command status */
 	int	nstat;		/* # status bytes */
-	int	confused;	/* controler needs to be reset */
+	int	confused;	/* controller needs to be reset */
 	Rendez	r;		/* wait here for command termination */
 	int	motor;		/* bit mask of spinning disks */
 };

--- a/os/pc/vgatvp3020.c
+++ b/os/pc/vgatvp3020.c
@@ -12,7 +12,7 @@
 #include "screen.h"
 
 /*
- * TVP3020 Viewpoint Video Interface Pallette.
+ * TVP3020 Viewpoint Video Interface Palette.
  * Assumes hooked up to an S3 86C928.
  */
 enum {

--- a/os/pc/vgatvp3026.c
+++ b/os/pc/vgatvp3026.c
@@ -12,7 +12,7 @@
 #include "screen.h"
 
 /*
- * TVP3026 Viewpoint Video Interface Pallette.
+ * TVP3026 Viewpoint Video Interface Palette.
  * Assumes hooked up to an S3 Vision968.
  */
 enum {

--- a/os/port/chan.c
+++ b/os/port/chan.c
@@ -1360,7 +1360,7 @@ char isfrog[256]={
  *  a) is in valid memory.
  *  b) is shorter than 2^16 bytes, so it can fit in a 9P string field.
  *  c) contains no frogs.
- * The first byte is known to be addressible by the requester, so the
+ * The first byte is known to be addressable by the requester, so the
  * routine works for kernel and user memory both.
  * The parameter slashok flags whether a slash character is an error
  * or a valid character.

--- a/os/port/cis.c
+++ b/os/port/cis.c
@@ -227,7 +227,7 @@ microvolt(Cisdat *cis)
 			return 0;
 		switch(c){
 		case 0x7d:
-			break;		/* high impedence when sleeping */
+			break;		/* high impedance when sleeping */
 		case 0x7e:
 		case 0x7f:
 			microvolts = 0;	/* no connection */

--- a/os/port/dev.c
+++ b/os/port/dev.c
@@ -199,7 +199,7 @@ devwalk(Chan *c, Chan *nc, char **name, int nname, Dirtab *tab, int ntab, Devgen
 	}
 	/*
 	 * We processed at least one name, so will return some data.
-	 * If we didn't process all nname entries succesfully, we drop
+	 * If we didn't process all nname entries successfully, we drop
 	 * the cloned channel and return just the Qids of the walks.
 	 */
 Done:

--- a/os/port/devbridge.c
+++ b/os/port/devbridge.c
@@ -1066,7 +1066,7 @@ fragment(Etherpkt *epkt, int n)
 	if(n < IPHDR)
 		return 0;
 
-	// check it is ok IP packet - I don't handle IP options for the momment
+	// check it is ok IP packet - I don't handle IP options for the moment
 	if(iphdr->vihl != (IP_VER|IP_HLEN))
 		return 0;
 

--- a/os/port/devftl.c
+++ b/os/port/devftl.c
@@ -274,7 +274,7 @@ ftlgen(Chan *c, char*, Dirtab*, int, int i, Dir *dp)
 				i--;
 			}
 		if(i != 0){
-			print("wierd\n");
+			print("weird\n");
 			return -1;
 		}
 		devdir(c, (Qid){Qdata + 1 + n, 0, QTFILE}, ftls->part[n].name, ftls->part[n].size, eve, 0660, dp);

--- a/os/port/flashif.h
+++ b/os/port/flashif.h
@@ -118,7 +118,7 @@ void	flashput(Flash*, ulong, int);
  */
 
 /*
- * do any device spcific initialisation
+ * do any device specific initialisation
  */
 void archnand_init(Flash*);
 

--- a/os/port/portdat.h
+++ b/os/port/portdat.h
@@ -622,7 +622,7 @@ enum
 	Qmsg		= (1<<1),	/* message stream */
 	Qclosed		= (1<<2),	/* queue has been closed/hungup */
 	Qflow		= (1<<3),	/* producer flow controlled */
-	Qcoalesce	= (1<<4),	/* coallesce packets on read */
+	Qcoalesce	= (1<<4),	/* coalesce packets on read */
 	Qkick		= (1<<5),	/* always call the kick routine after qwrite */
 };
 

--- a/services/httpd/httpd.suff
+++ b/services/httpd/httpd.suff
@@ -28,13 +28,13 @@
 .etx		text		x-setext	-		# [Mosaic]
 .exe		application	octet-stream	-		# DOS executable
 .executable	application	octet-stream	-		# DOS executable
-.exz		application	octet-stream	x-gzip		# gziped DOS executable
+.exz		application	octet-stream	x-gzip		# gzipped DOS executable
 .f		text		plain		-		# fortran-77 program
 .flc		video		x-flc		-
 .fli		video		x-fli		-
 .gif		image		gif		-
 .gtar		application	x-gtar		-		# [Mosaic]
-.gz		-		-		x-gzip		# gziped file
+.gz		-		-		x-gzip		# gzipped file
 .h		text		plain		-		# C header file
 .hdf		application	x-hdf		-
 .hqx		application	octet-stream	-		# Mac BinHex

--- a/utils/0c/cgen.c
+++ b/utils/0c/cgen.c
@@ -393,7 +393,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -877,7 +877,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -970,7 +970,7 @@ sugen(Node *n, Node *nn, long w)
 			break;
 		}
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/0c/mul.c
+++ b/utils/0c/mul.c
@@ -62,7 +62,7 @@ mulcon0(long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/0c/swt.c
+++ b/utils/0c/swt.c
@@ -655,7 +655,7 @@ align(long i, Type *t, int op)
 			w = packflg;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -676,7 +676,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_VLONG) {
 			w = SZ_VLONG;
@@ -690,7 +690,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael1);
 		o = align(o, t, Ael2);
 		break;

--- a/utils/5c/cgen.c
+++ b/utils/5c/cgen.c
@@ -445,7 +445,7 @@ cgenrel(Node *n, Node *nn, int inrel)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -900,7 +900,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -993,7 +993,7 @@ sugen(Node *n, Node *nn, long w)
 			break;
 		}
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/5c/mul.c
+++ b/utils/5c/mul.c
@@ -63,7 +63,7 @@ mulcon0(long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/6c/cgen.c
+++ b/utils/6c/cgen.c
@@ -358,7 +358,7 @@ cgen(Node *n, Node *nn)
 				gopcode(OMUL, n->type, &nod1, &nod);
 				regfree(&nod1);
 			}else
-				gopcode(OMUL, n->type, r, &nod);	/* addressible */
+				gopcode(OMUL, n->type, r, &nod);	/* addressable */
 			gmove(&nod, nn);
 			regfree(&nod);
 			break;
@@ -1013,7 +1013,7 @@ cgen(Node *n, Node *nn)
 		sugen(l, nodrat, l->type->width);
 		if(nn == Z)
 			break;
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		nod = *nodrat;
 		if(!r || r->op != OCONST) {
 			diag(n, "DOT and no offset");
@@ -1424,7 +1424,7 @@ sugen(Node *n, Node *nn, long w)
 		sugen(l, nodrat, l->type->width);
 		if(nn == Z)
 			break;
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		nod1 = *nodrat;
 		r = n->right;
 		if(!r || r->op != OCONST) {
@@ -1519,7 +1519,7 @@ sugen(Node *n, Node *nn, long w)
 		}
 
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/6c/swt.c
+++ b/utils/6c/swt.c
@@ -492,7 +492,7 @@ align(long i, Type *t, int op)
 		w = SZ_VLONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael1);
 		o = align(o, t, Ael2);
 		break;

--- a/utils/8a/l.s
+++ b/utils/8a/l.s
@@ -136,7 +136,7 @@ TEXT	origin(SB),$0
  */
 /*
  *	relocate everything to a half meg and jump there
- *	- looks wierd because it is being assembled by a 32 bit
+ *	- looks weird because it is being assembled by a 32 bit
  *	  assembler for a 16 bit world
  */
 	MOVL	$0,BX
@@ -173,7 +173,7 @@ TEXT	lowcore(SB),$0
 	MOVL	AX,CR0
 
 /*
- *	clear prefetch queue (wierd code to avoid optimizations)
+ *	clear prefetch queue (weird code to avoid optimizations)
  */
 	CLC
 	JCC	flush

--- a/utils/8c/cgen.c
+++ b/utils/8c/cgen.c
@@ -1021,7 +1021,7 @@ cgen(Node *n, Node *nn)
 		sugen(l, nodrat, l->type->width);
 		if(nn == Z)
 			break;
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		nod = *nodrat;
 		if(!r || r->op != OCONST) {
 			diag(n, "DOT and no offset");
@@ -1489,7 +1489,7 @@ sugen(Node *n, Node *nn, long w)
 		sugen(l, nodrat, l->type->width);
 		if(nn == Z)
 			break;
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		nod1 = *nodrat;
 		r = n->right;
 		if(!r || r->op != OCONST) {
@@ -1584,7 +1584,7 @@ sugen(Node *n, Node *nn, long w)
 		}
 
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/8c/swt.c
+++ b/utils/8c/swt.c
@@ -446,7 +446,7 @@ align(long i, Type *t, int op)
 			w = packflg;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -467,7 +467,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_LONG) {
 			w = SZ_LONG;
@@ -481,7 +481,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael1);
 		o = align(o, t, Ael2);
 		break;

--- a/utils/awk/FIXES
+++ b/utils/awk/FIXES
@@ -68,7 +68,7 @@ Apr 21, 2000:
 	jon bentley for the test case that found it.
 
 	added test in envinit to catch environment "variables" with
-	names begining with '='; thanks to Berend Hasselman.
+	names beginning with '='; thanks to Berend Hasselman.
 
 Jul 28, 1999:
 	added test in defn() to catch function foo(foo), which
@@ -305,7 +305,7 @@ May 2, 1996:
 	some awful behaviors.)
 
 Apr 29, 1996:
-	replaced uchar by uschar everwhere; apparently some compilers
+	replaced uchar by uschar everywhere; apparently some compilers
 	usurp this name and this causes conflicts.
 
 	fixed call to time in run.c (bltin); arg is time_t *.

--- a/utils/c2l/c2l.c
+++ b/utils/c2l/c2l.c
@@ -3601,7 +3601,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -3620,7 +3620,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_LONG) {
 			w = SZ_LONG;
@@ -3634,7 +3634,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael2);
 		o = align(o, t, Ael1);
 		w = SZ_LONG;	/* because of a pun in cc/dcl.c:contig() */

--- a/utils/ic/cgen.c
+++ b/utils/ic/cgen.c
@@ -423,7 +423,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -944,7 +944,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -1037,7 +1037,7 @@ sugen(Node *n, Node *nn, long w)
 			break;
 		}
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/ic/mul.c
+++ b/utils/ic/mul.c
@@ -62,7 +62,7 @@ mulcon0(long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/iyacc/yacc.c
+++ b/utils/iyacc/yacc.c
@@ -2274,7 +2274,7 @@ go2out(void)
 {
 	int i, j, k, best, count, cbest, times;
 
-	/* mark begining of gotos */
+	/* mark beginning of gotos */
 	Bprint(ftemp, "$\n");
 	for(i = 1; i <= nnonter; i++) {
 		go2gen(i);

--- a/utils/kc/cgen.c
+++ b/utils/kc/cgen.c
@@ -399,7 +399,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -820,7 +820,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -914,7 +914,7 @@ sugen(Node *n, Node *nn, long w)
 		}
 		/* BOTCH -- functions can clobber rathole */
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/kc/mul.c
+++ b/utils/kc/mul.c
@@ -62,7 +62,7 @@ mulcon0(Node *n, long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/kc/swt.c
+++ b/utils/kc/swt.c
@@ -526,7 +526,7 @@ align(long i, Type *t, int op)
 			w = packflg;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -547,7 +547,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_LONG) {
 			w = SZ_LONG;
@@ -562,7 +562,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael1);
 		o = align(o, t, Ael2);
 		break;

--- a/utils/kl/asm.c
+++ b/utils/kl/asm.c
@@ -847,7 +847,7 @@ asmout(Prog *p, Optab *o, int aflag)
 		break;
 
 	case 42:	/* ldd -> ldf,ldf */
-		/* note should be ldd with proper allignment */
+		/* note should be ldd with proper alignment */
 		r = p->from.reg;
 		if(r == NREG)
 			r = o->param;
@@ -873,7 +873,7 @@ asmout(Prog *p, Optab *o, int aflag)
 		break;
 
 	case 44:	/* std -> stf,stf */
-		/* note should be std with proper allignment */
+		/* note should be std with proper alignment */
 		r = p->to.reg;
 		if(r == NREG)
 			r = o->param;
@@ -893,7 +893,7 @@ asmout(Prog *p, Optab *o, int aflag)
 		break;
 
 	case 46:	/* ldd lorg -> ldf,ldf */
-		/* note should be ldd with proper allignment */
+		/* note should be ldd with proper alignment */
 		r = p->from.reg;
 		if(r == NREG)
 			r = o->param;
@@ -915,7 +915,7 @@ asmout(Prog *p, Optab *o, int aflag)
 		break;
 
 	case 48:	/* std lorg -> stf,stf */
-		/* note should be std with proper allignment */
+		/* note should be std with proper alignment */
 		r = p->to.reg;
 		if(r == NREG)
 			r = o->param;

--- a/utils/libmach/kdb.c
+++ b/utils/libmach/kdb.c
@@ -438,7 +438,7 @@ sparcinst(Map *map, uvlong pc, char modifier, char *buf, int n)
 {
 	static int fmtinstalled = 0;
 
-		/* a modifier of 'I' toggles the dissassembler type */
+		/* a modifier of 'I' toggles the disassembler type */
 	if (!fmtinstalled) {
 		fmtinstalled = 1;
 		fmtinstall('T', Tfmt);

--- a/utils/libmach/sym.c
+++ b/utils/libmach/sym.c
@@ -25,7 +25,7 @@ struct file {				/* Per input file header to history stack */
 	uvlong	addr;			/* address of first text sym */
 	/* union { */
 		Txtsym	*txt;		/* first text symbol */
-		Sym	*sym;		/* only during initilization */
+		Sym	*sym;		/* only during initialization */
 	/* }; */
 	int	n;			/* size of history stack */
 	Hist	*hist;			/* history stack */

--- a/utils/libregexp/regcomp.h
+++ b/utils/libregexp/regcomp.h
@@ -27,7 +27,7 @@ extern Reprog	RePrOg;
 #define	RBRA		0201	/* Right bracket, ) */
 #define	LBRA		0202	/* Left bracket, ( */
 #define	OR		0203	/* Alternation, | */
-#define	CAT		0204	/* Concatentation, implicit operator */
+#define	CAT		0204	/* Concatenation, implicit operator */
 #define	STAR		0205	/* Closure, * */
 #define	PLUS		0206	/* a+ == aa* */
 #define	QUEST		0207	/* a? == a|nothing, i.e. 0 or 1 a's */

--- a/utils/mk/Plan9.c
+++ b/utils/mk/Plan9.c
@@ -97,7 +97,7 @@ exportenv(Envy *e)
 			hasvalue = 0;
 		else
 			hasvalue = 1;
-		if(sy == 0 && !hasvalue)	/* non-existant null symbol */
+		if(sy == 0 && !hasvalue)	/* non-existent null symbol */
 			continue;
 		sprint(nam, "/env/%s", e->name);
 		if (sy != 0 && !hasvalue) {	/* Remove from environment */

--- a/utils/mk/archive-AIX.c
+++ b/utils/mk/archive-AIX.c
@@ -27,7 +27,7 @@ atimeof(int force, char *name)
 	}
 	else{
 		atimes(archive);
-		/* mark the aggegate as having been done */
+		/* mark the aggregate as having been done */
 		symlook(strdup(archive), S_AGG, "")->value = (void *)t;
 	}
 	snprint(buf, sizeof(buf), "%s(%s)", archive, member);

--- a/utils/mk/archive.c
+++ b/utils/mk/archive.c
@@ -27,7 +27,7 @@ atimeof(int force, char *name)
 	}
 	else{
 		atimes(archive);
-		/* mark the aggegate as having been done */
+		/* mark the aggregate as having been done */
 		symlook(strdup(archive), S_AGG, "")->value = (void *)t;
 	}
 		/* truncate long member name to sizeof of name field in archive header */

--- a/utils/mk/mk.c
+++ b/utils/mk/mk.c
@@ -87,7 +87,7 @@ work(Node *node, Node *p, Arc *parc)
 		}else
 			return(did);
 	}
-	/* consider no prerequsite case */
+	/* consider no prerequisite case */
 	if(node->prereqs == 0){
 		if(node->time == 0){
 			fprint(2, "mk: don't know how to make '%s'\n", node->name);

--- a/utils/mk/run.c
+++ b/utils/mk/run.c
@@ -107,7 +107,7 @@ waitup(int echildok, int *retstatus)
 	Process *p;
 	extern int runerrs;
 
-	/* first check against the proces slist */
+	/* first check against the process slist */
 	if(retstatus)
 		for(p = phead; p; p = p->f)
 			if(p->pid == *retstatus){

--- a/utils/ntsrv/ntsrv.c
+++ b/utils/ntsrv/ntsrv.c
@@ -86,7 +86,7 @@ usage()
 
 /* (from rcsh)
  * windows quoting rules - I think
- * Words are seperated by space or tab
+ * Words are separated by space or tab
  * Words containing a space or tab can be quoted using "
  * 2N backslashes + " ==> N backslashes and end quote
  * 2N+1 backslashes + " ==> N backslashes + literal "

--- a/utils/qc/cgen.c
+++ b/utils/qc/cgen.c
@@ -443,7 +443,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -852,7 +852,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -947,7 +947,7 @@ sugen(Node *n, Node *nn, long w)
 		}
 		/* BOTCH -- functions can clobber rathole */
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;
@@ -1124,7 +1124,7 @@ layout(Node *f, Node *t, int c, int cv, Node *cn)
 }
 
 /*
- * is the vlong's value directly addressible?
+ * is the vlong's value directly addressable?
  */
 int
 isvdirect(Node *n)

--- a/utils/qc/mul.c
+++ b/utils/qc/mul.c
@@ -62,7 +62,7 @@ mulcon0(Node *n, long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/rcsh/Nt.c
+++ b/utils/rcsh/Nt.c
@@ -190,7 +190,7 @@ refdec(Ref *r)
 
 /*
  * windows quoting rules - I think
- * Words are seperated by space or tab
+ * Words are separated by space or tab
  * Words containing a space or tab can be quoted using "
  * 2N backslashes + " ==> N backslashes and end quote
  * 2N+1 backslashes + " ==> N backslashes + literal "
@@ -337,7 +337,7 @@ setpath(char *path, char *file)
 		}
 	}
 
-	/* get rid of trailling \ */
+	/* get rid of trailing \ */
 	if(path[n-1] == '\\') {
 		if(n <= 2) {
 			werrstr("illegal file name");

--- a/utils/rcsh/lex.c
+++ b/utils/rcsh/lex.c
@@ -200,7 +200,7 @@ yylex(void)
 
 	yylval.tree=0;
 	/*
-	 * Embarassing sneakiness:  if the last token read was a quoted or unquoted
+	 * Embarrassing sneakiness:  if the last token read was a quoted or unquoted
 	 * WORD then we alter the meaning of what follows.  If the next character
 	 * is `(', we return SUB (a subscript paren) and consume the `('.  Otherwise,
 	 * if the next character is the first character of a simple or compound word,

--- a/utils/rcsh/rc.h
+++ b/utils/rcsh/rc.h
@@ -37,7 +37,7 @@ typedef	struct Direntry Direntry;
 
 #define	NSTATUS	64			/* length of status (from plan 9) */
 
-#define	IWS	0x01	/* inter word seperator when word lists are stored in env variables */
+#define	IWS	0x01	/* inter word separator when word lists are stored in env variables */
 
 /*
  * Glob character escape in strings:

--- a/utils/tc/cgen.c
+++ b/utils/tc/cgen.c
@@ -485,7 +485,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -970,7 +970,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -1063,7 +1063,7 @@ sugen(Node *n, Node *nn, long w)
 			break;
 		}
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/tc/mul.c
+++ b/utils/tc/mul.c
@@ -63,7 +63,7 @@ mulcon0(long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/tc/swt.c
+++ b/utils/tc/swt.c
@@ -662,7 +662,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -681,7 +681,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_LONG) {
 			w = SZ_LONG;
@@ -695,7 +695,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael2);
 		o = align(o, t, Ael1);
 		w = SZ_LONG;	/* because of a pun in cc/dcl.c:contig() */

--- a/utils/tl/noop.c
+++ b/utils/tl/noop.c
@@ -241,7 +241,7 @@ noops(void)
 #ifdef CALLEEBX
 			if(p->from.sym->foreign){
 				if(thumb)
-					// don't allow literal pool to seperate these
+					// don't allow literal pool to separate these
 					p = adword(0xe28f7001, 0xe12fff17, p); // arm add 1, pc, r7 and bx r7
 					// p = aword(0xe12fff17, aword(0xe28f7001, p)); // arm add 1, pc, r7 and bx r7
 				else

--- a/utils/vc/cgen.c
+++ b/utils/vc/cgen.c
@@ -403,7 +403,7 @@ cgen(Node *n, Node *nn)
 	case ODOT:
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod = *nodrat;
 			if(!r || r->op != OCONST) {
 				diag(n, "DOT and no offset");
@@ -915,7 +915,7 @@ sugen(Node *n, Node *nn, long w)
 		l = n->left;
 		sugen(l, nodrat, l->type->width);
 		if(nn != Z) {
-			warn(n, "non-interruptable temporary");
+			warn(n, "non-interruptible temporary");
 			nod1 = *nodrat;
 			r = n->right;
 			if(!r || r->op != OCONST) {
@@ -1008,7 +1008,7 @@ sugen(Node *n, Node *nn, long w)
 			break;
 		}
 		sugen(n->right, nodrat, w);
-		warn(n, "non-interruptable temporary");
+		warn(n, "non-interruptible temporary");
 		sugen(nodrat, n->left, w);
 		sugen(nodrat, nn, w);
 		break;

--- a/utils/vc/mul.c
+++ b/utils/vc/mul.c
@@ -62,7 +62,7 @@ mulcon0(long v)
 	mulval = v;
 
 	/*
-	 * look in execption hint table
+	 * look in exception hint table
 	 */
 	a1 = 0;
 	a2 = hintabsize;

--- a/utils/vc/swt.c
+++ b/utils/vc/swt.c
@@ -528,7 +528,7 @@ align(long i, Type *t, int op)
 			w = packflg;
 		break;
 
-	case Ael1:	/* initial allign of struct element */
+	case Ael1:	/* initial align of struct element */
 		for(v=t; v->etype==TARRAY; v=v->link)
 			;
 		w = ewidth[v->etype];
@@ -549,7 +549,7 @@ align(long i, Type *t, int op)
 		}
 		break;
 
-	case Aarg1:	/* initial allign of parameter */
+	case Aarg1:	/* initial align of parameter */
 		w = ewidth[t->etype];
 		if(w <= 0 || w >= SZ_LONG) {
 			w = SZ_LONG;
@@ -565,7 +565,7 @@ align(long i, Type *t, int op)
 		w = SZ_LONG;
 		break;
 
-	case Aaut3:	/* total allign of automatic */
+	case Aaut3:	/* total align of automatic */
 		o = align(o, t, Ael1);
 		o = align(o, t, Ael2);
 		break;


### PR DESCRIPTION
Fixed as many typos and spelling errors as I could, but I'm sure I've missed a few.

Changes should have no effect on functionality and were made for the purpose of improving comment legibility and quality of documentation.

Happy New Year.