### PR TITLE
Add whois(1)

### DIFF
--- a/appl/cmd/mkfile
+++ b/appl/cmd/mkfile
@@ -170,6 +170,7 @@ TARG=\
 	wav2iaf.dis\
 	wc.dis\
 	webgrab.dis\
+	whois.dis\
 	wish.dis\
 	wmexport.dis\
 	wmimport.dis\

--- a/appl/cmd/whois.b
+++ b/appl/cmd/whois.b
@@ -1,0 +1,89 @@
+implement Whois;
+
+include "sys.m"; sys: Sys;
+include "draw.m";
+include "dial.m"; dial: Dial;
+include "arg.m";
+
+Whois: module {
+	init: fn(nil: ref Draw->Context, args: list of string);
+};
+
+init(nil: ref Draw->Context, args: list of string) {
+	sys = load Sys Sys->PATH;
+	dial = load Dial Dial->PATH;
+	arg := load Arg Arg->PATH;
+
+	addr := "tcp!whois.iana.org!43";
+	expect_refer := 5;
+
+	arg->init(args);
+	arg->setusage("whois [-a addr] [-n] host");
+	while((opt := arg->opt()) != 0) {
+		case opt {
+		'a' =>
+			addr = dial->netmkaddr(arg->earg(), "tcp", "43");
+		'n' =>
+			expect_refer = 0;
+		* =>
+			arg->usage();
+		}
+	}
+
+	args = arg->argv();
+	if(len args != 1)
+		arg->usage();
+
+	host := hd args;
+	fd := whois(addr, host);
+
+	buf := array[512] of byte;
+	stdout := sys->fildes(1);
+	while((i := sys->read(fd, buf, len buf)) > 0) {
+		if(expect_refer) {
+			ls := sys->tokenize(string buf[0:i], "\n").t1;
+			newaddr: string = nil;
+			while(ls != nil) {
+				l := hd ls;
+				(n, rs) := sys->tokenize(l, " \t");
+				if(n == 2 && hd rs == "refer:") {
+					newaddr = dial->netmkaddr(hd tl rs, "tcp", "43");
+					break;
+				} else if(n == 3 && hd rs == "Whois" && hd tl rs == "Server:") {
+					newaddr = dial->netmkaddr(hd tl tl rs, "tcp", "43");
+					break;
+				}
+				ls = tl ls;
+			}
+			if(newaddr != nil) {
+				fd = whois(newaddr, host);
+				expect_refer--;
+				continue;
+			}
+		}
+		sys->write(stdout, buf, i);
+	}
+	if(i < 0) {
+		sys->fprint(sys->fildes(2), "whois: reading info: %r\n");
+		raise "fail:errors";
+	}
+}
+
+whois(addr: string, host: string): ref Sys->FD
+{
+	sys->print("[using server %s]\n", addr);
+	conn := dial->dial(addr, nil);
+	if(conn == nil) {
+		sys->fprint(sys->fildes(2), "whois: dialing %s: %r\n", addr);
+		raise "fail:errors";
+	}
+
+	fd := conn.dfd;
+	i := sys->fprint(fd, "%s\r\n", host);
+	if(i != len host + 2) {
+		sys->fprint(sys->fildes(2), "whois: sending name: %r\n");
+		raise "fail:errors";
+	}
+
+	return fd;
+}

--- a/man/1/whois
+++ b/man/1/whois
@@ -1,0 +1,40 @@
+.TH WHOIS 1
+.SH NAME
+whois \- query whois databases
+.SH SYNOPSIS
+.B whois
+[
+.B -a
+.I server
+]
+[
+.B -n
+]
+.I host
+.SH DESCRIPTION
+.I Whois
+queries whois servers to find owner information for domain names and
+network addresses.  By default, it looks for referrals to other whois
+database servers and queries the next server in the chain if it finds
+one.
+
+.TP
+.B -a
+Specify a different server to start the query.  (Default:
+.I tcp!whois.iana.org!43
+)
+.TP
+.B -n
+Do not attempt to follow referrals.
+.SH EXAMPLE
+To query for the owner of a domain and then an IP address, using a
+specific server while ignoring referrals to other servers:
+.IP
+.EX
+whois inferno-os.org
+whois -a whois.ripe.net -n 148.251.6.120
+.EE
+.SH SOURCE
+.B /appl/cmd/whois.b
+.SH "SEE ALSO"
+.IR RFC3912


### PR DESCRIPTION
This is a small implementation of a whois client.  I have been using it for years without issue.

It behaves a little better than the versions that try to determine the server to use by applying heuristics to the name:  it does not ever go out of date, a frequent problem with the "standard" whois, but at the cost of possibly passing rate limits from the intermediate servers if used for bulk lookups.