### PR TITLE
Add uniq -c

### DIFF
--- a/appl/cmd/uniq.b
+++ b/appl/cmd/uniq.b
@@ -13,7 +13,7 @@ Uniq: module
 
 usage()
 {
-	fail("usage", sys->sprint("usage: uniq [-ud] [file]"));
+	fail("usage", sys->sprint("usage: uniq [-udc] [file]"));
 }
 
 init(nil : ref Draw->Context, args : list of string)
@@ -31,6 +31,7 @@ init(nil : ref Draw->Context, args : list of string)
 
 	uflag := 0;
 	dflag := 0;
+	cflag := 0;
 	arg->init(args);
 	while ((opt := arg->opt()) != 0) {
 		case opt {
@@ -38,6 +39,8 @@ init(nil : ref Draw->Context, args : list of string)
 			uflag = 1;
 		'd' =>
 			dflag = 1;
+		'c' =>
+			cflag = 1;
 		* =>
 			usage();
 		}
@@ -61,14 +64,20 @@ init(nil : ref Draw->Context, args : list of string)
 		if (s == prev)
 			n++;
 		else {
-			if ((uflag && n == 1) || (dflag && n > 1))
+			if ((uflag && n == 1) || (dflag && n > 1)) {
+				if(cflag)
+					prev = string n + "\t" + prev;
 				stdout.puts(prev);
+			}
 			n = 1;
 			prev = s;
 		}
 	}
-	if ((uflag && n == 1) || (dflag && n > 1))
+	if ((uflag && n == 1) || (dflag && n > 1)) {
+		if(cflag)
+			prev = string n + "\t" + prev;
 		stdout.puts(prev);
+	}
 	stdout.close();
 }
 

--- a/man/1/uniq
+++ b/man/1/uniq
@@ -4,7 +4,7 @@ uniq \- report repeated lines in a file
 .SH SYNOPSIS
 .B uniq
 [
-.B -ud
+.B -udc
 ]
 [
 .I file
@@ -23,6 +23,9 @@ in order to be found.
 .TP
 .B -u
 Print unique lines.
+.TP
+.B -c
+Prefix a repetition count and a tab to each output line.
 .TP
 .B -d
 Print (one copy of) duplicated lines.


### PR DESCRIPTION
Trivial change to uniq to allow `uniq -c`.  Man page change was copied from the Plan 9 man page.