### PR TITLE
Multiple small fixes

### DIFF
--- a/appl/charon/mkfile
+++ b/appl/charon/mkfile
@@ -86,7 +86,7 @@ $ROOT/dis/charon.dis:	charon.dis
 charon.dis:	$MODULES $SYS_MODULES
 
 img.dis:	img.b $MODULE $SYS_MODULE
-	limbo $LIMBOFLAGS -c -gw img.b
+	limbo $LIMBOFLAGS -gw img.b
 
 nuke:V:
 	rm -f $ROOT/dis/charon.dis

--- a/appl/svc/httpd/httpd.b
+++ b/appl/svc/httpd/httpd.b
@@ -506,8 +506,6 @@ senddir(g: ref Private_info,vers,uri: string, fd: ref FD, mydir: ref Dir)
 	g.bout.puts("<table>\n");
 	for(i := 0; i < n; i++){
 		(typ, enc) := classify(a[i]);
-		#g.bout.puts(sys->sprint("<tr><td><a href=\"%s%s\">%s</A></td>",
-		#	myname, a[i].name, a[i].name));
 		g.bout.puts(sys->sprint("<tr><td><a href=\"%s\">%s</A></td>",
 			a[i].name, a[i].name));
 		if(typ != nil){

--- a/appl/svc/httpd/httpd.b
+++ b/appl/svc/httpd/httpd.b
@@ -506,8 +506,10 @@ senddir(g: ref Private_info,vers,uri: string, fd: ref FD, mydir: ref Dir)
 	g.bout.puts("<table>\n");
 	for(i := 0; i < n; i++){
 		(typ, enc) := classify(a[i]);
-		g.bout.puts(sys->sprint("<tr><td><a href=\"%s%s\">%s</A></td>",
-			myname, a[i].name, a[i].name));
+		#g.bout.puts(sys->sprint("<tr><td><a href=\"%s%s\">%s</A></td>",
+		#	myname, a[i].name, a[i].name));
+		g.bout.puts(sys->sprint("<tr><td><a href=\"%s\">%s</A></td>",
+			a[i].name, a[i].name));
 		if(typ != nil){
 			if(typ.generic!=nil)
 				g.bout.puts(sys->sprint("<td>%s", typ.generic));

--- a/appl/svc/httpd/httpd.suff
+++ b/appl/svc/httpd/httpd.suff
@@ -15,6 +15,7 @@
 .bcpio		application	x-bcpio		-		# [Mosaic]
 .bib		text		plain		-		# BibTex input
 .c		text		plain		-		# C program
+.css	text		css		-	# CSS
 .c++		text		plain		-		# C++ program
 .cc		text		plain		-		# [Mosaic]
 .cdf		application	x-netcdf	-
@@ -76,6 +77,7 @@
 .rfr		text		plain		-		# refer
 .rgb		image		x-rgb		-		# [Mosaic]
 .roff		application	x-troff		-		# [Mosaic]
+.rss		application	rss+xml		-		# RSS feeds
 .rtf		application	rtf		-		# [Mosaic]
 .rtx		text		richtext 	-	# MIME richtext	  [Mosaic]
 .sh		application	x-shar		-
@@ -83,6 +85,7 @@
 .snd		audio		basic		-
 .sv4cpio	application	x-sv4cpio	-		# [Mosaic]
 .sv4crc		application	x-sv4crc	-		# [Mosaic]
+.svg		image	svg+xml		-		# SVG images
 .t		application	x-troff		-		# [Mosaic]
 .tar		application	x-tar		-		# [Mosaic]
 .taz		application	x-tar		x-compress

--- a/appl/wm/memory.b
+++ b/appl/wm/memory.b
@@ -109,9 +109,9 @@ realinit(ctxt: ref Draw->Context)
 				maxx+x,
 				a[i].y + 8);
 			cmd(t, s);
-			s = sys->sprint(".c itemconfigure %s -text '%s", a[i].tagsz, string a[i].size);
+			s = sys->sprint(".c itemconfigure %s -text '%s", a[i].tagsz, sizestr(a[i].size));
 			cmd(t, s);
-			s = sys->sprint(".c itemconfigure %s -text '%d", a[i].tagiu, a[i].allocs-a[i].frees);
+			s = sys->sprint(".c itemconfigure %s -text '%s", a[i].tagiu, sizestr(a[i].allocs-a[i].frees));
 			cmd(t, s);
 		}
 		cmd(t, "update");
@@ -163,7 +163,7 @@ initdraw(n: int): int
 
 sizestr(n: int): string
 {
-	if ((n / 1024) % 1024 == 0)
+	if ((n / 1024) % 1024 == 0 || n > (100 * 1024 * 1024))
 		return string (n / (1024 * 1024)) + "M";
 	return string (n / 1024) + "K";
 }

--- a/emu/port/win-x11a.c
+++ b/emu/port/win-x11a.c
@@ -969,7 +969,7 @@ xinitscreen(int xsize, int ysize, ulong reqchan, ulong *chan, int *d)
 	}
 
 	clipboard = XInternAtom(xmcon, "CLIPBOARD", False);
-	utf8string = XInternAtom(xmcon, "UTF8_STRING", False);
+	utf8string = XInternAtom(xmcon, "UTF8_STRING", True);
 	targets = XInternAtom(xmcon, "TARGETS", False);
 	text = XInternAtom(xmcon, "TEXT", False);
 	compoundtext = XInternAtom(xmcon, "COMPOUND_TEXT", False);
@@ -1523,7 +1523,7 @@ _xgetsnarf(XDisplay *xd)
 	 */
 	prop = 1;
 	XChangeProperty(xd, xdrawable, prop, XA_STRING, 8, PropModeReplace, (uchar*)"", 0);
-	XConvertSelection(xd, clipboard, XA_STRING, prop, xdrawable, CurrentTime);
+	XConvertSelection(xd, clipboard, utf8string, prop, xdrawable, CurrentTime);
 	XFlush(xd);
 	lastlen = 0;
 	for(i=0; i<10 || (lastlen!=0 && i<30); i++){

--- a/lib/units
+++ b/lib/units
@@ -595,3 +595,4 @@ weymass			252 lb
 Xunit			1.00202e-13 m
 k			1.38047e-16 erg/°K
 foal			9223372036854775807
+romanmile		1620 yard

--- a/libdraw/font.c
+++ b/libdraw/font.c
@@ -355,6 +355,8 @@ fontresize(Font *f, int wid, int ncache, int depth)
 	d = f->display;
 	if(depth <= 0)
 		depth = 1;
+	if(wid == 0)
+		wid = 1;
 
 	new = allocimage(d, Rect(0, 0, ncache*wid, f->height), CHAN1(CGrey, depth), 0, 0);
 	if(new == nil){

--- a/services/httpd/httpd.suff
+++ b/services/httpd/httpd.suff
@@ -15,6 +15,7 @@
 .bcpio		application	x-bcpio		-		# [Mosaic]
 .bib		text		plain		-		# BibTex input
 .c		text		plain		-		# C program
+.css	text		css		-	# CSS
 .c++		text		plain		-		# C++ program
 .cc		text		plain		-		# [Mosaic]
 .cdf		application	x-netcdf	-
@@ -76,6 +77,7 @@
 .rfr		text		plain		-		# refer
 .rgb		image		x-rgb		-		# [Mosaic]
 .roff		application	x-troff		-		# [Mosaic]
+.rss		application	rss+xml		-		# RSS feeds
 .rtf		application	rtf		-		# [Mosaic]
 .rtx		text		richtext 	-	# MIME richtext	  [Mosaic]
 .sh		application	x-shar		-
@@ -83,6 +85,7 @@
 .snd		audio		basic		-
 .sv4cpio	application	x-sv4cpio	-		# [Mosaic]
 .sv4crc		application	x-sv4crc	-		# [Mosaic]
+.svg		image	svg+xml		-		# SVG images
 .t		application	x-troff		-		# [Mosaic]
 .tar		application	x-tar		-		# [Mosaic]
 .taz		application	x-tar		x-compress


### PR DESCRIPTION
This is a bundle of small patches I have been running locally for years, and I believe they're reasonable to submit upstream.  So as not to inundate you with a dozen small pull requests, I have pushed the changes into a single branch, but am happy to separate any or all of them into their own branch/PR.  (In my repo here and at https://git.debu.gs/gitweb/?p=inferno , I have a number of personal changes that are probably best confined to my own system, but this is nearly all of the ones that are generally useful.)

* Remove the `-c` flag when compiling `img.dis` in Charon, so that Charon can run without JIT enabled.
* Fix a crash in `libdraw/font.c` when handling zero-width characters.
* Request UTF-8 strings from the X server.  (This allows pasting non-ASCII strings into acme, which is useful; there is a note in `emu/port/lib-x11a.c` about performance, but I have not observed any performance degradation, even on small ARM machines.)
* Some small fixes for the httpd:  directory listings were duplicating paths (thus resulting in 404s if you tried to click on any of the filenames in a subdirectory), and add a few more file types.
* Add `romanmile` to `units(1)`.

These changes are sensible, I think, but they are somewhat more subjective:

* Make `wm/memory` slightly more legible by displaying megabytes when a number exceeds 100 kilobytes; the current behavior is to only round if it is an exactly even number of kilobytes, so 1200kB is displayed in MB but 1201kB is displayed in kB.
* Apply caerwyn's changes to `wm/view` to display 24-bit color where available.