### PR TITLE
Added a missing freetype include path

### DIFF
--- a/libfreetype/mkfile
+++ b/libfreetype/mkfile
@@ -82,6 +82,6 @@ OFILES=\
 
 <$ROOT/mkfiles/mksyslib-$SHELLTYPE
 
-CFLAGS= $ANSICPP $CFLAGS -DFT2_BUILD_LIBRARY
+CFLAGS= $ANSICPP $CFLAGS -DFT2_BUILD_LIBRARY -Ilibfreetype/include
 
 freetype.$O:	$ROOT/include/freetype.h


### PR DESCRIPTION
Adds an additional include path so that the freetype build works.
The earlier freetype update somehow didn't manage to need this when I tested it.