### PR TITLE
Removed duplicate libfreetype submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "freetype2"]
-	path = libfreetype2
-	url = https://github.com/freetype/freetype.git
-[submodule "libfreetype/libfreetype"]
 	path = libfreetype/libfreetype
 	url = https://github.com/freetype/freetype.git


### PR DESCRIPTION
I somehow managed to create two entries for the same submodule. This removes one of them.