### PR TITLE
Treat Thumb and Thumb-2 floating point code differently

### DIFF
--- a/utils/tl/obj.c
+++ b/utils/tl/obj.c
@@ -1482,7 +1482,9 @@ static void
 puntfp(Prog *p)
 {
 	USED(p);
-        return;
+	// Don't punt on Thumb-2 floating point.
+	if(debug['2']) return;
+
 	/* floating point - punt for now */
 	curtext->reg = NREG;	/* ARM */
 	curtext->from.sym->thumb = 0;


### PR DESCRIPTION
Apparently, the Thumb toolchain is used in 9front to build Gameboy Advance binaries, which pre-date Thumb-2 by quite some time.
This change requires Thumb-2 builds to pass the -2 option to tl, which shouldn't be a problem.