### PR TITLE
ARM JIT fixes

### DIFF
--- a/libinterp/comp-arm.c
+++ b/libinterp/comp-arm.c
@@ -1309,7 +1309,7 @@ comp(Inst *i)
 		}
 		tinit[i->s.imm] = 1;
 		con((ulong)mod->type[i->s.imm], RA3, 1);
-		CALL(base+macro[MacFRAM]);
+		CALLMAC(AL, MacFRAM);
 		opwst(i, Stw, RA2);
 		break;
 	case INEWCB:
@@ -2069,7 +2069,7 @@ comd(Type *t)
 		for(m = 0x80; m != 0; m >>= 1) {
 			if(c & m) {
 				mem(Ldw, j, RFP, RA0);
-				CALL(base+macro[MacFRP]);
+				CALLMAC(AL, MacFRP);
 			}
 			j += sizeof(WORD*);
 		}

--- a/libinterp/comp-arm.c
+++ b/libinterp/comp-arm.c
@@ -704,8 +704,6 @@ nullity(void)
 static void
 punt(Inst *i, int m, void (*fn)(void))
 {
-	ulong pc;
-
 	if(m & SRCOP) {
 		if(UXSRC(i->add) == SRC(AIMM))
 			literal(i->s.imm, O(REG, s));
@@ -724,8 +722,7 @@ punt(Inst *i, int m, void (*fn)(void))
 		mem(Stw, O(REG, PC), RREG, RA0);
 	}
 	if(m & DBRAN) {
-		pc = patch[i->d.ins-mod->prog];
-		literal((ulong)(base+pc), O(REG, d));
+		literal(RELPC(i->d.ins-mod->prog), O(REG, d));
 	}
 
 	switch(i->add&ARM) {

--- a/libinterp/comp-arm.c
+++ b/libinterp/comp-arm.c
@@ -1780,21 +1780,23 @@ preamble(void)
 	if(comvec)
 		return;
 
-	comvec = malloc(10 * sizeof(*code));
+	comvec = malloc(12 * sizeof(*code));
 	if(comvec == nil)
 		error(exNomem);
 	code = (ulong*)comvec;
 
+	*code++ = 0xe92d4bf0;	/* push {r4-r9, r11, lr} */
 	con((ulong)&R, RREG, 0);
-	mem(Stw, O(REG, xpc), RREG, RLINK);
 	mem(Ldw, O(REG, FP), RREG, RFP);
 	mem(Ldw, O(REG, MP), RREG, RMP);
+	mem(Stw, O(REG, xpc), RREG, R15); /* return to pop below */
 	mem(Ldw, O(REG, PC), RREG, R15);
+	*code++ = 0xe8bd8bf0;	/* pop {r4-r9, r11, pc} */
 	pass++;
 	flushcon(0);
 	pass--;
 
-	segflush(comvec, 10 * sizeof(*code));
+	segflush(comvec, 12 * sizeof(*code));
 }
 
 static void

--- a/libinterp/comp-arm.c
+++ b/libinterp/comp-arm.c
@@ -2148,12 +2148,12 @@ patchex(Module *m, ulong *p)
 	if((h = m->htab) == nil)
 		return;
 	for( ; h->etab != nil; h++){
-		h->pc1 = p[h->pc1];
-		h->pc2 = p[h->pc2];
+		h->pc1 = p[h->pc1] * 4;
+		h->pc2 = p[h->pc2] * 4;
 		for(e = h->etab; e->s != nil; e++)
-			e->pc = p[e->pc];
+			e->pc = p[e->pc] * 4;
 		if(e->pc != -1)
-			e->pc = p[e->pc];
+			e->pc = p[e->pc] * 4;
 	}
 }
 

--- a/libinterp/comp-arm.c
+++ b/libinterp/comp-arm.c
@@ -2169,7 +2169,7 @@ compile(Module *m, int size, Modlink *ml)
 	ulong *s, *tmp;
 
 	base = nil;
-	patch = mallocz(size*sizeof(*patch), 0);
+	patch = mallocz((size+1)*sizeof(*patch), 0);
 	tinit = malloc(m->ntype*sizeof(*tinit));
 	tmp = malloc(4096*sizeof(ulong));
 	if(tinit == nil || patch == nil || tmp == nil)
@@ -2178,16 +2178,16 @@ compile(Module *m, int size, Modlink *ml)
 	preamble();
 
 	mod = m;
-	n = 0;
 	pass = 0;
 	nlit = 0;
 
+	patch[0] = n = 0;
 	for(i = 0; i < size; i++) {
 		codeoff = n;
 		code = tmp;
 		comp(&m->prog[i]);
-		patch[i] = n;
 		n += code - tmp;
+		patch[i+1] = n;
 	}
 
 	for(i = 0; i < nelem(mactab); i++) {
@@ -2218,12 +2218,12 @@ compile(Module *m, int size, Modlink *ml)
 	for(i = 0; i < size; i++) {
 		s = code;
 		comp(&m->prog[i]);
-		if(patch[i] != n) {
+		n += code - s;
+		if(patch[i+1] != n) {
 			print("%3d %D\n", i, &m->prog[i]);
-			print("%lud != %d\n", patch[i], n);
+			print("%lud != %d\n", patch[i+1], n);
 			urk("phase error");
 		}
-		n += code - s;
 		if(cflag > 4) {
 			print("%3d %D\n", i, &m->prog[i]);
 			das(s, code-s);


### PR DESCRIPTION
In the preamble code (comvec) save callee-saved registers clobbered by the JIT code and arrange to restore them on return.  Makes JIT work on arm when xec.c compiled with optimizations.

r11 doesn't seem to be used by the JIT, but we need to keep 8 byte alignment of the stack pointer.