### PR TITLE
libinterp/conv.c: disassemble (%D) "raise" argument correctly

### DIFF
--- a/libinterp/conv.c
+++ b/libinterp/conv.c
@@ -72,8 +72,14 @@ Dconv(Fmt *f)
 		sprint(buf, "%s", opnam[i->op]);
 		break;
 	case TOKI1:
-		d.a = i->d;
-		d.mode = UDST(i->add);
+		if (i->op == IRAISE) {
+			/* cf. appl/cmd/asm/asm.b */
+			d.a = i->s;
+			d.mode = USRC(i->add);
+		} else {
+			d.a = i->d;
+			d.mode = UDST(i->add);
+		}
 		sprint(buf, "%s\t%a", opnam[i->op], &d);
 		break;
 	case TOKI3:


### PR DESCRIPTION
This is a minimal kludge that does the inverse of what appl/cmd/asm/asm.b does for "raise".  There's probably a better way to do it.

This fixes in particular the debugging dump of JIT'ted code from `-c5`.