### PR TITLE
venti: Session.read(): Handle reads for 0-score/any type locally

### DIFF
--- a/appl/lib/venti.b
+++ b/appl/lib/venti.b
@@ -323,6 +323,10 @@ Session.new(fd: ref Sys->FD): ref Session
 
 Session.read(s: self ref Session, score: Score, etype: int, maxn: int): array of byte
 {
+	if (Score.eq(score, Score.zero()) {
+		return array[0] of byte;
+	}
+
 	(gm, err) := s.rpc(ref Vmsg.Tread(1, 0, score, etype, maxn));
 	if(gm == nil){
 		sys->werrstr(err);


### PR DESCRIPTION
vac archives may have the zero-score (da39...) with any type. I've observed type VtDirType + 3, for a single 720 MiB file, for example.

The reference venti server will not find zero-score blocks with type != 0; and the reference client does not send reads for zero-score blocks regardless of type (see libventi/client.c: vtreadpacket).

Implement the same logic in venti.b.