### PR TITLE
Fix check for null termination of a option string

### DIFF
--- a/emu/port/main.c
+++ b/emu/port/main.c
@@ -69,7 +69,7 @@ geom(char *val)
 {
 	char *p;
 	int x, y;
-	if (val == '\0' || (*val < '0' || *val > '9')) 
+	if (*val == '\0' || (*val < '0' || *val > '9'))
 		return 0;
 	x = strtoul(val, &p, 0);
 	if(x >= 64) 


### PR DESCRIPTION
Intended to check whether a geometry value is an empty string.